### PR TITLE
feat(imageController,imageRoute): 新增基于key的图片上传接口

### DIFF
--- a/src/routes/imageRoutes.js
+++ b/src/routes/imageRoutes.js
@@ -11,5 +11,7 @@ imageRoutes.delete('/delete', imageController.deleteImages)
 // imageRoutes.get('/listr2', imageController.listR2Images)
 imageRoutes.post('/list', imageController.listImages)
 
+// 新增：无需认证的上传路由
+imageRoutes.post('/upload-with-key', imageController.uploadImageWithKey)
 
 export { imageRoutes } 


### PR DESCRIPTION
1. 新增 /image/upload-with-key 路由，支持通过URL参数传递key进行认证
2. 新增 uploadImageWithKey 控制器方法，支持多文件上传
3. 使用时间戳格式生成文件名
4. 适配前端返回格式，返回完整的图片URL
5. 复用现有的文件验证逻辑，包括类型和大小限制